### PR TITLE
Remove name from the header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![](https://raw.githubusercontent.com/balena-io-projects/balena-sound/master/images/balenaSound-logo.png)
 
-# balenaSound - Bluetooth audio streaming for any audio device
+# Bluetooth audio streaming for any audio device
 
 **Starter project enabling you to add bluetooth audio streaming to any old speakers or Hi-Fi using just a Raspberry Pi.**
 


### PR DESCRIPTION
It's a bit nicer. Name is in the logo and the header fits one line now.

Change-type: patch
Signed-off-by: Robert Vojta <robert@balena.io>