### PR TITLE
Nicer log output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,6 @@ You can change this using `BLUETOOTH_DEVICE_NAME` environment variable that can 
 
 ![Setting the device name](images/device-name-config.png)
 
-If you modify the Bluetooth device name after deploying the application, you should restart `bluetooth-audio` service
-to apply the changes.
-
 ### Deploy this application
 
 * Install the [balena CLI tools](https://github.com/balena-io/balena-cli/blob/master/INSTALL.md)

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To run this project is as simple as deploying it to a balenaCloud application; n
 By default, your device will be displayed as `balenaSound xxxx` when you search for Bluetooth devices.
 You can change this using `BLUETOOTH_DEVICE_NAME` environment variable that can be set in balena dashboard
 (navigate to dashboard -> app -> device -> device variables).
+
 ![Setting the device name](images/device-name-config.png)
 
 If you modify the Bluetooth device name after deploying the application, you should restart `bluetooth-audio` service

--- a/bluetooth-audio/bluetooth-agent
+++ b/bluetooth-audio/bluetooth-agent
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     manager = dbus.Interface(obj, "org.bluez.AgentManager1")
     manager.RegisterAgent(path, capability)
 
-    print("Agent registered")
+    print("Bluetooth agent registered")
 
     manager.RequestDefaultAgent(path)
 

--- a/bluetooth-audio/start.sh
+++ b/bluetooth-audio/start.sh
@@ -4,15 +4,19 @@ if [[ -z "$BLUETOOTH_DEVICE_NAME" ]]; then
   BLUETOOTH_DEVICE_NAME=$(printf "balenaSound %s" $(hostname | cut -c -4))
 fi
 
-# set the discoverable timeout here
-dbus-send --system --dest=org.bluez --print-reply /org/bluez/hci0 org.freedesktop.DBus.Properties.Set string:'org.bluez.Adapter1' string:'DiscoverableTimeout' variant:uint32:0
+# Set the discoverable timeout here
+dbus-send --system --dest=org.bluez /org/bluez/hci0 org.freedesktop.DBus.Properties.Set string:'org.bluez.Adapter1' string:'DiscoverableTimeout' variant:uint32:0
 
-printf "\nSetting volume to 100%%\n"
+printf "Setting volume to 100%%\n"
 amixer sset PCM,0 100% > /dev/null &
 
-service bluetooth restart
+printf "Restarting bluetooth service\n"
+service bluetooth restart > /dev/null
 sleep 2
-printf "discoverable on\npairable on\nexit\n" | bluetoothctl
+
+# Redirect stdout to null, because it prints the old BT device name, which
+# can be confusing and it also hides those commands from the logs as well.
+printf "discoverable on\npairable on\nexit\n" | bluetoothctl > /dev/null
 
 /usr/src/bluetooth-agent &
 
@@ -24,4 +28,5 @@ hciconfig hci0 up
 hciconfig hci0 name "$BLUETOOTH_DEVICE_NAME"
 
 sleep 2
+printf "Device is discoverable as \"%s\"\n" "$BLUETOOTH_DEVICE_NAME"
 /usr/bin/bluealsa-aplay --pcm-buffer-time=1000000 00:00:00:00:00:00


### PR DESCRIPTION
* Add space just before the screenshot
* Remove paragraph about service restart (supervisor auto magic)
* Unnecessary output from the logs silenced

```
05.07.19 15:34:22 (+0200)  bluetooth-audio  Setting volume to 100%
05.07.19 15:34:22 (+0200)  bluetooth-audio  Restarting bluetooth service
05.07.19 15:34:26 (+0200)  bluetooth-audio  Bluetooth agent registered
05.07.19 15:34:30 (+0200)  bluetooth-audio  Device is discoverable as "FooBar with Space"
05.07.19 15:39:42 (+0200) Killing service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:54 (+0200) Service exited 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:54 (+0200) Killed service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:55 (+0200) Installing service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:56 (+0200) Installed service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:56 (+0200) Starting service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:58 (+0200) Started service 'bluetooth-audio sha256:cf0190e7a26824470cd0d58287fe015703c9feb6f4f5653fc31c2aee20bc86c1'
05.07.19 15:39:59 (+0200)  bluetooth-audio  Setting volume to 100%
05.07.19 15:39:59 (+0200)  bluetooth-audio  Restarting bluetooth service
05.07.19 15:40:02 (+0200)  bluetooth-audio  Bluetooth agent registered
05.07.19 15:40:06 (+0200)  bluetooth-audio  Device is discoverable as "Foo Bar Hooray"
```