### PR TITLE
Restore disabling timeout functionality

### DIFF
--- a/bluetooth-audio/start.sh
+++ b/bluetooth-audio/start.sh
@@ -5,7 +5,7 @@ if [[ -z "$BLUETOOTH_DEVICE_NAME" ]]; then
 fi
 
 # Set the discoverable timeout here
-dbus-send --system --dest=org.bluez /org/bluez/hci0 org.freedesktop.DBus.Properties.Set string:'org.bluez.Adapter1' string:'DiscoverableTimeout' variant:uint32:0
+dbus-send --system --dest=org.bluez --print-reply /org/bluez/hci0 org.freedesktop.DBus.Properties.Set string:'org.bluez.Adapter1' string:'DiscoverableTimeout' variant:uint32:0 > /dev/null
 
 printf "Setting volume to 100%%\n"
 amixer sset PCM,0 100% > /dev/null &


### PR DESCRIPTION
Using dbus-send in this manner without --print-reply causes it to
silently fail.

Change-type: patch
Signed-off-by: Chris Crocker-White <chriscw@balena.io>