### PR TITLE
Change base image to Debian Stretch instead of Buster

### DIFF
--- a/bluetooth-audio/Dockerfile.template
+++ b/bluetooth-audio/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM balenalib/%%BALENA_MACHINE_NAME%%:buster
+FROM balenalib/%%BALENA_MACHINE_NAME%%:stretch
 
 ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 


### PR DESCRIPTION
Fixes https://github.com/balena-io-projects/balena-sound/issues/15
The use of Buster instead of Stretch breaks balena-sound. This reverts back to Stretch until the Buster issues can be worked out.

Change-type: patch