### PR TITLE
Fix to make spotify container build for a Pi 4 app

### DIFF
--- a/spotify/Dockerfile.aarch64
+++ b/spotify/Dockerfile.aarch64
@@ -1,0 +1,17 @@
+FROM balenalib/raspberrypi3:buster
+
+ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+ENV BITRATE 160
+ENV CACHE_ARGS --disable-audio-cache
+ENV VOLUME_ARGS --enable-volume-normalisation --linear-volume --initial-volume=100
+ENV BACKEND_ARGS --backend alsa
+
+RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
+  && echo 'deb https://dtcooper.github.io/raspotify jessie main' | tee /etc/apt/sources.list.d/raspotify.list \
+  && install_packages raspotify
+
+CMD /bin/mkdir -m 0755 -p /var/cache/raspotify ; /bin/chown raspotify:raspotify /var/cache/raspotify
+
+COPY start.sh /usr/src/
+
+CMD bash /usr/src/start.sh


### PR DESCRIPTION
I had tested this container previously on a Pi4 but it was part of a multi-arch app. This fixes the container for a Pi4 specific app.
