### PR TITLE
Add Pin Code support.

### DIFF
--- a/bluetooth-audio/Dockerfile.aarch64
+++ b/bluetooth-audio/Dockerfile.aarch64
@@ -8,6 +8,7 @@ RUN install_packages \
   alsa-utils \
   bluealsa \
   bluez \
+  bluez-tools \
   python-gobject \
   python-dbus \
   mplayer
@@ -21,10 +22,6 @@ COPY sounds /usr/src/sounds
 COPY bluetooth-udev /usr/src/
 RUN chmod +x /usr/src/bluetooth-udev
 COPY udev-rules/ /etc/udev/rules.d/
-
-# Bluetooth-agent handles the auth of devices
-COPY bluetooth-agent /usr/src/
-RUN chmod +x /usr/src/bluetooth-agent
 
 COPY start.sh /usr/src/
 RUN chmod +x /usr/src/start.sh

--- a/bluetooth-audio/Dockerfile.template
+++ b/bluetooth-audio/Dockerfile.template
@@ -8,6 +8,7 @@ RUN install_packages \
   alsa-utils \
   bluealsa \
   bluez \
+  bluez-tools \
   python-gobject \
   python-dbus \
   mplayer
@@ -21,10 +22,6 @@ COPY sounds /usr/src/sounds
 COPY bluetooth-udev /usr/src/
 RUN chmod +x /usr/src/bluetooth-udev
 COPY udev-rules/ /etc/udev/rules.d/
-
-# Bluetooth-agent handles the auth of devices
-COPY bluetooth-agent /usr/src/
-RUN chmod +x /usr/src/bluetooth-agent
 
 COPY start.sh /usr/src/
 RUN chmod +x /usr/src/start.sh

--- a/bluetooth-audio/start.sh
+++ b/bluetooth-audio/start.sh
@@ -4,6 +4,14 @@ if [[ -z "$BLUETOOTH_DEVICE_NAME" ]]; then
   BLUETOOTH_DEVICE_NAME=$(printf "balenaSound %s" $(hostname | cut -c -4))
 fi
 
+if [[ -z "$BLUETOOTH_PIN_CODE" ]]; then
+  BLUETOOTH_PIN_CODE=0000
+fi
+
+cat <<EOF > /usr/src/bluetooth.cfg
+* $BLUETOOTH_PIN_CODE
+EOF
+
 # Set the system volume here
 SYSTEM_OUTPUT_VOLUME="${SYSTEM_OUTPUT_VOLUME:-100}"
 echo $SYSTEM_OUTPUT_VOLUME > /usr/src/system_output_volume
@@ -26,7 +34,9 @@ sleep 2
 # can be confusing and it also hides those commands from the logs as well.
 printf "discoverable on\npairable on\nexit\n" | bluetoothctl > /dev/null
 
-/usr/src/bluetooth-agent &
+hciconfig hci0 sspmode 0
+
+bt-agent -p /usr/src/bluetooth.cfg &
 
 sleep 2
 rm -rf /var/run/bluealsa/


### PR DESCRIPTION
Change-type: minor
@chrisys I tested this on a RPI 3. It works very good and not only with numbers or limits of numbers. You can set BLUETOOTH_PIN_CODE to: 1 or 12 or 123 or 1234 or 123456789 and so on. The limit of numbers is 1-∞.  You can also set letters:
Balena or Sound1234!* or AlexProgrammerDE12345678910*'+#!"§$%&/() . There are no limits.
If BLUETOOTH_PIN_CODE is not set the pin code is 0000. I have made the bluetooth-agent file useless so we can delete it in a future release. You can write in the future also a README information. I hope you will have the same results like me. 

