### PR TITLE
Make raspotify more clear, add cache and add default output volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,7 @@ services:
     restart: always
     network_mode: host
     privileged: true
-    labels:
-      io.balena.features.dbus: 1
+    volumes:
+      - spotifycache:/var/cache/raspotify
+volumes:
+  spotifycache:

--- a/spotify/Dockerfile.aarch64
+++ b/spotify/Dockerfile.aarch64
@@ -1,16 +1,8 @@
 FROM balenalib/raspberrypi3:buster
 
-ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-ENV BITRATE 160
-ENV CACHE_ARGS --disable-audio-cache
-ENV VOLUME_ARGS --enable-volume-normalisation --linear-volume --initial-volume=100
-ENV BACKEND_ARGS --backend alsa
-
 RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
   && echo 'deb https://dtcooper.github.io/raspotify jessie main' | tee /etc/apt/sources.list.d/raspotify.list \
   && install_packages raspotify
-
-CMD /bin/mkdir -m 0755 -p /var/cache/raspotify ; /bin/chown raspotify:raspotify /var/cache/raspotify
 
 COPY start.sh /usr/src/
 

--- a/spotify/Dockerfile.template
+++ b/spotify/Dockerfile.template
@@ -1,16 +1,8 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%:buster
 
-ENV DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-ENV BITRATE 160
-ENV CACHE_ARGS --disable-audio-cache
-ENV VOLUME_ARGS --enable-volume-normalisation --linear-volume --initial-volume=100
-ENV BACKEND_ARGS --backend alsa
-
 RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
   && echo 'deb https://dtcooper.github.io/raspotify jessie main' | tee /etc/apt/sources.list.d/raspotify.list \
   && install_packages raspotify
-
-CMD /bin/mkdir -m 0755 -p /var/cache/raspotify ; /bin/chown raspotify:raspotify /var/cache/raspotify
 
 COPY start.sh /usr/src/
 

--- a/spotify/start.sh
+++ b/spotify/start.sh
@@ -4,4 +4,8 @@ if [[ -z "$BLUETOOTH_DEVICE_NAME" ]]; then
   BLUETOOTH_DEVICE_NAME=$(printf "balenaSound %s" $(hostname | cut -c -4))
 fi
 
-./usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" $BACKEND_ARGS --bitrate ${BITRATE} $CACHE_ARGS $VOLUME_ARGS
+# Set the system volume here
+SYSTEM_OUTPUT_VOLUME="${SYSTEM_OUTPUT_VOLUME:-100}"
+
+# Start raspotify
+./usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" --backend alsa --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME


### PR DESCRIPTION
Change-type: minor

I now added some features to spotify connect and improved the music quality.
I have no premium so i could not test it. Thanks in advance.

- [x] Set the Bitrate to 320 for better music quality.
- [x] Add default volume (100), which can be customized (SYSTEM_OUTPUT_VOLUME)
- [x] Put the variables from the dockerfile in the start script
- [x] Delete useless dbus variable
- [x] Add music cache (This will help by internet lags.)
- [x] Add a cache Volume

bugs: