### PR TITLE
Patch readme exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,16 +70,3 @@ By default, balenaSound bluetooth will connect using Secure Simple Pairing mode.
 * Let the music play!
 
 This project is in active development so if you have any feature requests or issues please submit them here on GitHub. PRs are welcome, too.
-
-## Multiple container use
-If you plan to use Balena Sound as part of a multiple container app (for example, having an app with PiHole & Balena sound), don't forget to add the following label to your `docker-compose.yml` file. (source: https://www.balena.io/docs/learn/develop/multicontainer/#labels)
-
-Example:
-```
-bluetooth:
-  build: ./bluetooth-audio
-  privileged: true
-  network_mode: host
-  labels:
-    io.balena.features.dbus: '1'
-```

--- a/airplay/Dockerfile.template
+++ b/airplay/Dockerfile.template
@@ -5,4 +5,4 @@ RUN install_packages shairport-sync
 
 COPY start.sh /usr/src/
 
-CMD bash /usr/src/start.sh
+CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/airplay/start.sh
+++ b/airplay/start.sh
@@ -4,4 +4,4 @@ if [[ -z "$BLUETOOTH_DEVICE_NAME" ]]; then
   BLUETOOTH_DEVICE_NAME=$(printf "balenaSound %s" $(hostname | cut -c -4))
 fi
 
-shairport-sync -a "$BLUETOOTH_DEVICE_NAME"
+exec shairport-sync -a "$BLUETOOTH_DEVICE_NAME"

--- a/bluetooth-audio/Dockerfile.aarch64
+++ b/bluetooth-audio/Dockerfile.aarch64
@@ -29,4 +29,5 @@ RUN chmod +x /usr/src/bluetooth-agent
 COPY start.sh /usr/src/
 RUN chmod +x /usr/src/start.sh
 
-CMD /usr/src/start.sh
+CMD [ "/bin/bash", "/usr/src/start.sh" ]
+

--- a/bluetooth-audio/Dockerfile.template
+++ b/bluetooth-audio/Dockerfile.template
@@ -29,4 +29,4 @@ RUN chmod +x /usr/src/bluetooth-agent
 COPY start.sh /usr/src/
 RUN chmod +x /usr/src/start.sh
 
-CMD /usr/src/start.sh
+CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/bluetooth-audio/start.sh
+++ b/bluetooth-audio/start.sh
@@ -54,4 +54,4 @@ fi
 
 sleep 2
 printf "Device is discoverable as \"%s\"\n" "$BLUETOOTH_DEVICE_NAME"
-/usr/bin/bluealsa-aplay --pcm-buffer-time=1000000 00:00:00:00:00:00
+exec /usr/bin/bluealsa-aplay --pcm-buffer-time=1000000 00:00:00:00:00:00

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     privileged: true
     labels:
       io.balena.features.dbus: 1
-      io.balena.features.supervisor-api: 1
     volumes:
       - bluetoothcache:/var/cache/bluetooth
   airplay:

--- a/spotify/Dockerfile.aarch64
+++ b/spotify/Dockerfile.aarch64
@@ -6,4 +6,4 @@ RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
 
 COPY start.sh /usr/src/
 
-CMD bash /usr/src/start.sh
+CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/spotify/Dockerfile.template
+++ b/spotify/Dockerfile.template
@@ -6,4 +6,4 @@ RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
 
 COPY start.sh /usr/src/
 
-CMD bash /usr/src/start.sh
+CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/spotify/start.sh
+++ b/spotify/start.sh
@@ -8,4 +8,4 @@ fi
 SYSTEM_OUTPUT_VOLUME="${SYSTEM_OUTPUT_VOLUME:-100}"
 
 # Start raspotify
-./usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" --backend alsa --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME
+exec /usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" --backend alsa --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME


### PR DESCRIPTION
Various patch changes:
+ bluetooth-audio: removed unnecessary 'io.balena.features.supervisor-api' label (not needed since this [commit](https://github.com/balena-io-projects/balena-sound/commit/51b6254a7893c889947cf2926dc863d1ee75cf95))
+ Readme: Removed mc instructions no longer needed.
+ Updated Dockerfiles to use the exec form of CMD (as per internal discussion)


Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>