### PR TITLE
Add Spotify login and suppress the build error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ By default, balenaSound bluetooth will connect using Secure Simple Pairing mode.
 balenaSound has configurable scripts you can run on connect and disconnect bluetooth events. If you would like to activate this, set the  `BLUETOOTH_SCRIPTS` environment variable to `true`.
 Sample scripts can be found on the `./bluetooth-audio/bluetooh-scripts/` directory, theses can be edited as needed.
 
+### Spotify login (optional)
+
+By default, balenaSound Spotify Connect won´t login to your Spotify account.
+To make your device visible on Spotify Connect across the Internet can you add your
+username/e-mail and password, which can be set with these two enviroment variables: `SPOTIFY_LOGIN` and `SPOTIFY_PASSWORD`
+
 ## Connect
 
 * After the application has pushed and the device has downloaded the latest changes you're ready to go!

--- a/spotify/Dockerfile.aarch64
+++ b/spotify/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 FROM balenalib/raspberrypi3:buster
 
-RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
+RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - 2> /dev/null \
   && echo 'deb https://dtcooper.github.io/raspotify jessie main' | tee /etc/apt/sources.list.d/raspotify.list \
   && install_packages raspotify
 

--- a/spotify/Dockerfile.template
+++ b/spotify/Dockerfile.template
@@ -1,6 +1,6 @@
 FROM balenalib/%%BALENA_MACHINE_NAME%%:buster
 
-RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - \
+RUN curl -sSL https://dtcooper.github.io/raspotify/key.asc | apt-key add -v - 2> /dev/null \
   && echo 'deb https://dtcooper.github.io/raspotify jessie main' | tee /etc/apt/sources.list.d/raspotify.list \
   && install_packages raspotify
 

--- a/spotify/start.sh
+++ b/spotify/start.sh
@@ -7,5 +7,11 @@ fi
 # Set the system volume here
 SYSTEM_OUTPUT_VOLUME="${SYSTEM_OUTPUT_VOLUME:-100}"
 
+# Set the raspotify username and password
+if [ ! -z "$SPOTIFY_LOGIN" ] && [ ! -z "$SPOTIFY_PASSWORD" ]; then
+  SPOTIFY_CREDENTIALS="--username $SPOTIFY_LOGIN --password $SPOTIFY_PASSWORD"
+  printf "%s\n" "Using Spotify login."
+fi
+
 # Start raspotify
-exec /usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" --backend alsa --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME
+exec /usr/bin/librespot  --name "$BLUETOOTH_DEVICE_NAME" --backend alsa --bitrate 320 --cache /var/cache/raspotify --enable-volume-normalisation --linear-volume --initial-volume=$SYSTEM_OUTPUT_VOLUME $SPOTIFY_CREDENTIALS


### PR DESCRIPTION
Change-type: minor
Connects-to: #73

Hi,
in this PR i implement the in #73 requested feature.
- [x] Add spotify login option
- [x] Suppress the build error message of the gpg agent, caused by the terminal
- [x] Write README info

bugs: 
- [x] I didnt add the parameter.

recommends:
- [x] https://github.com/balena-io-projects/balena-sound/pull/75#issuecomment-569975348