### PR TITLE
sound-supervisor: update dependency to fix build

### DIFF
--- a/core/sound-supervisor/package.json
+++ b/core/sound-supervisor/package.json
@@ -18,7 +18,7 @@
     "balena-sdk": "^15.39.1",
     "cote": "^1.0.0",
     "express": "^4.17.1",
-    "express-async-handler": "^1.1.4",
+    "express-async-handler": "~1.1.4",
     "ts-retry-promise": "^0.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Looks like [`express-async-handler`](https://www.npmjs.com/package/express-async-handler) dependency was updated 5 days ago and that broke some types. Pinning the package to previous version known to work.



Closes: #502
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>