### PR TITLE
patch: Upgrade librespot

### DIFF
--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -1,7 +1,8 @@
-FROM andrewn/librespot:0.4.2-pulseaudio
+FROM giof71/librespot
 
 ENV PULSE_SERVER=tcp:localhost:4317
 
 COPY start.sh /usr/src/
 
+ENTRYPOINT []
 CMD [ "/bin/bash", "/usr/src/start.sh" ]

--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -1,5 +1,4 @@
-FROM giof71/librespot:stable
-
+FROM giof71/librespot:feature-i152b1-bookworm
 ENV PULSE_SERVER=tcp:localhost:4317
 
 COPY start.sh /usr/src/

--- a/plugins/spotify/Dockerfile.template
+++ b/plugins/spotify/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM giof71/librespot
+FROM giof71/librespot:stable
 
 ENV PULSE_SERVER=tcp:localhost:4317
 

--- a/plugins/spotify/start.sh
+++ b/plugins/spotify/start.sh
@@ -45,6 +45,7 @@ set -- /usr/bin/librespot \
   --bitrate "$SOUND_SPOTIFY_BITRATE" \
   --cache /var/cache/raspotify \
   --volume-ctrl linear \
+  --zeroconf-backend libmdns \
   "$@"
 
 exec "$@"


### PR DESCRIPTION
`librespot` as been updated quite a few times since 0.4.2. It seems that the new API is used and authentication has been hardened. 

@GioF71 has released a [docker image](https://github.com/GioF71/librespot-docker) which builds cross platform images with github actions. This is really handy as building librespot for muliple platform is kind of long...

Hence this PR is a proposal to switch from @andrewn's image to Giovanni's one. This will make us jump to librespot 0.6.0.
So far this fixes #669 and #671 for my setup. Only a few hours of testing though but I can see in the log that 502 errors are handled without dropping audio.

```
 spotify  [2025-03-01T15:11:42Z INFO  librespot_playback::player] Loading <Colours Fly> with Spotify URI <spotify:track:4iwIvzR9ZENkaH32bPZuB5>
 spotify  [2025-03-01T15:11:42Z ERROR librespot_connect::spirc] ContextError: Error { kind: Unknown, error: StatusCode(502) }
 spotify  [2025-03-01T15:11:43Z INFO  librespot_playback::player] <Colours Fly> (295706 ms) loaded
```
