### PR TITLE
Sound-supervisor would not build

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -10,7 +10,7 @@ assets:
   repository:
     type: blob.asset
     data:
-      url: 'https://github.com/JaragonCR/iotsound'
+      url: 'https://github.com/iotsound/iotsound'
   logo:
     type: blob.asset
     data:

--- a/balena.yml
+++ b/balena.yml
@@ -10,7 +10,7 @@ assets:
   repository:
     type: blob.asset
     data:
-      url: 'https://github.com/iotsound/iotsound'
+      url: 'https://github.com/JaragonCR/iotsound'
   logo:
     type: blob.asset
     data:

--- a/core/sound-supervisor/src/SoundAPI.ts
+++ b/core/sound-supervisor/src/SoundAPI.ts
@@ -10,11 +10,9 @@ import { getSdk, BalenaSDK } from 'balena-sdk'
 import * as fs from 'fs'
 
 let VERSION = '1.0.1';
-try {
-  VERSION = fs.readFileSync('VERSION', 'utf8').trim();
-} catch (err) {
-  console.warn('VERSION file not found. Using default version.');
-}
+const VERSION = fs.existsSync('VERSION') 
+  ? fs.readFileSync('VERSION', 'utf8').trim() 
+  : '1.0.0'; // or whatever your default version we decide```
 
 export default class SoundAPI {
   private api: Application

--- a/core/sound-supervisor/src/SoundAPI.ts
+++ b/core/sound-supervisor/src/SoundAPI.ts
@@ -9,10 +9,9 @@ import { restartDevice, rebootDevice, shutdownDevice } from './utils'
 import { getSdk, BalenaSDK } from 'balena-sdk'
 import * as fs from 'fs'
 
-let VERSION = '1.0.1';
 const VERSION = fs.existsSync('VERSION') 
   ? fs.readFileSync('VERSION', 'utf8').trim() 
-  : '1.0.0'; // or whatever your default version we decide```
+  : '3.11.0'; // last version before removal of VERSION```
 
 export default class SoundAPI {
   private api: Application

--- a/core/sound-supervisor/src/SoundAPI.ts
+++ b/core/sound-supervisor/src/SoundAPI.ts
@@ -9,9 +9,9 @@ import { restartDevice, rebootDevice, shutdownDevice } from './utils'
 import { getSdk, BalenaSDK } from 'balena-sdk'
 import * as fs from 'fs'
 
-let version = '1.0.1';
+let VERSION = = '1.0.1';
 try {
-  version = fs.readFileSync('VERSION', 'utf8').trim();
+  VERSION = fs.readFileSync('VERSION', 'utf8').trim();
 } catch (err) {
   console.warn('VERSION file not found. Using default version.');
 }

--- a/core/sound-supervisor/src/SoundAPI.ts
+++ b/core/sound-supervisor/src/SoundAPI.ts
@@ -9,7 +9,12 @@ import { restartDevice, rebootDevice, shutdownDevice } from './utils'
 import { getSdk, BalenaSDK } from 'balena-sdk'
 import * as fs from 'fs'
 
-const VERSION = fs.readFileSync('VERSION', 'utf-8')
+let version = '1.0.1';
+try {
+  version = fs.readFileSync('VERSION', 'utf8').trim();
+} catch (err) {
+  console.warn('VERSION file not found. Using default version.');
+}
 
 export default class SoundAPI {
   private api: Application

--- a/core/sound-supervisor/src/SoundAPI.ts
+++ b/core/sound-supervisor/src/SoundAPI.ts
@@ -9,7 +9,7 @@ import { restartDevice, rebootDevice, shutdownDevice } from './utils'
 import { getSdk, BalenaSDK } from 'balena-sdk'
 import * as fs from 'fs'
 
-let VERSION = = '1.0.1';
+let VERSION = '1.0.1';
 try {
   VERSION = fs.readFileSync('VERSION', 'utf8').trim();
 } catch (err) {


### PR DESCRIPTION
Sound supervisor was failing to build due to looking for a VERSION file that was removed with the branding cleanup. Declared a default version of 1.0.1 because I don't know what other applications depend on that version and allowed for this to work in the future if the file is readded. 